### PR TITLE
Move matplotlib import inside function

### DIFF
--- a/zeus/plotting.py
+++ b/zeus/plotting.py
@@ -1,6 +1,4 @@
 import numpy as np
-import matplotlib.pyplot as plt 
-import seaborn as sns
 
 def cornerplot(samples,
                labels=None,
@@ -66,6 +64,8 @@ def cornerplot(samples,
     Figure, Axes
         The matplotlib figure and axes.
     """
+    import matplotlib.pyplot as plt
+    import seaborn as sns
 
     ndim = samples.shape[1]
 


### PR DESCRIPTION
It's often useful to avoid importing matplotlib unless it's especially needed, since it can cause problems on some clusters and things like that.  This moves the matplotlib and seaborn imports inside the function that uses them, so they won't be imported unless called.