### PR TITLE
Add MANIFEST file so required files are distributed with the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE README.md requirements.txt


### PR DESCRIPTION
At the moment the files required by `setup.py` (`requirements.txt` and `README.md`) and the license file are not distributed with the package source. This PR adds a `MANIFEST.in` file, so that the required files are included in the distribution.