### PR TITLE
Remove error suppression by ChainManager in case of pickling failure

### DIFF
--- a/zeus/parallel.py
+++ b/zeus/parallel.py
@@ -271,8 +271,6 @@ class ChainManager:
         if self.pool is not None:
             self.pool.close()
 
-        return True
-
 
     @property
     def get_rank(self):


### PR DESCRIPTION
Hi, thanks for this great sampler!
I was having trouble getting my sampling to work with MPI, everything seemed to run fine, but I got no output. The reason was that my likelihood function was unpickleable, but that was a bit hard to track down, because the pickling errors were suppressed by the ChainManager. So here is a PR to no longer suppress these exceptions. Or if there is a good reason for it, or a better solution, then feel free to close this.