### PR TITLE
Provide user option to override default logging

### DIFF
--- a/zeus/ensemble.py
+++ b/zeus/ensemble.py
@@ -62,19 +62,25 @@ class EnsembleSampler:
                  check_walkers=True,
                  shuffle_ensemble=True,
                  light_mode=False,
+                 logger=None,
                  ):
 
         # Set up logger
-        self.logger = logging.getLogger()
-        for handler in self.logger.handlers[:]:
-            self.logger.removeHandler(handler)
-        handler = logging.StreamHandler()
-        self.logger.addHandler(handler)
-        if verbose:
-            self.logger.setLevel(logging.INFO)
+        if logger is None:
+            self.logger = logging.getLogger()
+            for handler in self.logger.handlers[:]:
+                self.logger.removeHandler(handler)
+            handler = logging.StreamHandler()
+            self.logger.addHandler(handler)
+            if verbose:
+                self.logger.setLevel(logging.INFO)
+            else:
+                self.logger.setLevel(logging.WARNING)
+        elif isinstance(logger, logging.Logger):
+            self.logger = logger
         else:
-            self.logger.setLevel(logging.WARNING)
-
+            raise ValueError("logger should be an instance of logging.Logger or None")
+            
         # Parse the move schedule
         if moves is None:
             self._moves = [DifferentialMove()]


### PR DESCRIPTION
When calling zeus from a script/package that does its own logging, the fact that zeus relies on the root logger is somewhat vexing as it may result in duplicate logging. This commit exposes the option to pass an existing logger to the sampler so that the user can modify logging behaviour if they so desire, or capture zeus' log output in the same streams as other logs. This also enables the user to prevent zeus from clobbering handlers that have already been defined for the root logger.

The changes do not alter the behaviour of existing code - the default of None ensures that any existing code will follow the current logic. While there are other ways of avoiding duplicate logs, this does provide more customisation options to users at rather low cost to maintain.