### PR TITLE
Change sklearn to scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ setuptools
 pytest
 matplotlib
 seaborn
-sklearn
+scikit-learn


### PR DESCRIPTION
Recently sklearn has started complaining if you call it sklearn in the requirements file instead of scikit-learn, with the error messages shown here: https://github.com/joezuntz/cosmosis/actions/runs/3883104663/jobs/6624021980