### PR TITLE
Typo in datafit.ipynb

### DIFF
--- a/docs/notebooks/datafit.ipynb
+++ b/docs/notebooks/datafit.ipynb
@@ -291,7 +291,7 @@
     "plt.figure(figsize=(16,1.5*ndim))\n",
     "for n in range(ndim):\n",
     "    plt.subplot2grid((ndim, 1), (n, 0))\n",
-    "    plt.plot(sampler.get_chain()[:,:,0], alpha=0.5)\n",
+    "    plt.plot(sampler.get_chain()[:,:,n], alpha=0.5)\n",
     "plt.tight_layout()\n",
     "plt.show()"
    ]


### PR DESCRIPTION
The graphs showing burn-in of the markov chains just displayed the same dimension twice. This has been fixed