### PR TITLE
Add warning not to intialize walkers in same starting place

### DIFF
--- a/zeus/ensemble.py
+++ b/zeus/ensemble.py
@@ -494,6 +494,9 @@ class EnsembleSampler:
         if not np.all(np.isfinite(Z)):
             raise ValueError('Invalid walker initial positions! \n' +
                              'Initialise walkers from positions of finite log probability.')
+        if self.nwalkers > 1 and (X == X[0]).all():
+            raise ValueError('Invalid walker initial positions! \n' +
+                             'Initialise walkers from different starting positions.')
         batch = list(np.arange(self.nwalkers))
 
         # Extend saving space


### PR DESCRIPTION
A PR to add an extra warning against user error if they initialize all the walkers in the same place. Based on this issue.
https://github.com/minaskar/zeus/issues/38

Here's the code I was using to test a correct vs incorrect initialization:
```
import numpy as np
from sklearn.datasets import make_spd_matrix
import matplotlib.pyplot as plt
import zeus


ndim = 10
nwalkers = 30
nsteps= 5000

C = make_spd_matrix(ndim)

icov = np.linalg.inv(C)

mu = np.random.rand(ndim)

def log_prob(x, mu, icov):
    return -0.5 * np.dot(np.dot((x-mu).T,icov),(x-mu))

# correct initialization
start = np.random.randn(nwalkers, ndim)


# incorrect initialization
start = np.random.randn(1, ndim)
start = np.tile(start, (nwalkers, 1))

print(start)


sampler = zeus.EnsembleSampler(nwalkers, ndim, log_prob, args=[mu, icov])
sampler.run_mcmc(start, nsteps)


print('Samples: ', sampler.samples.flatten(discard = 0).shape)
```